### PR TITLE
First working version of native device USB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-dma"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c8c02e4347a0267ca60813c952017f4c5948c232474c6010a381a337f1bda4"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +213,19 @@ dependencies = [
  "panel-protocol",
  "panic-halt",
  "stm32f1xx-hal",
+ "usb-device",
+ "usbd-serial",
+]
+
+[[package]]
+name = "stm32-usbd"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d13eca735cae37df697f599777b000cc0ee924df8452f2b4bfaa6798ab0338"
+dependencies = [
+ "cortex-m",
+ "usb-device",
+ "vcell",
 ]
 
 [[package]]
@@ -220,16 +242,17 @@ dependencies = [
 
 [[package]]
 name = "stm32f1xx-hal"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9b9e5d7c2901ee39fc9527412327a1fe08f1d84e9d7f4b3497448e655e5098"
+checksum = "bf679de34580d2f8806d9a6384c110b6df002404e1ff024cf8d567c91df4d4b2"
 dependencies = [
- "as-slice",
  "cast",
  "cortex-m",
  "cortex-m-rt",
+ "embedded-dma",
  "embedded-hal",
  "nb 0.1.3",
+ "stm32-usbd",
  "stm32f1",
  "void",
 ]
@@ -256,6 +279,23 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "usb-device"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "849eed9b4dc61a1f17ba1d7a5078ceb095b9410caa38a506eb281ed5eff12fbd"
+
+[[package]]
+name = "usbd-serial"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db75519b86287f12dcf0d171c7cf4ecc839149fe9f3b720ac4cfce52959e1dfe"
+dependencies = [
+ "embedded-hal",
+ "nb 0.1.3",
+ "usb-device",
+]
 
 [[package]]
 name = "vcell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,12 @@ edition = "2018"
 # The "medium" feature flag means "medium density", where "density" refers to the
 # amount of features on a given microcontroller
 # https://electronics.stackexchange.com/a/248187
-stm32f1xx-hal = {version = "0.6", features = ["rt", "stm32f103", "medium"] }
+stm32f1xx-hal = {version = "0.7", features = ["rt", "stm32f103", "medium", "stm32-usbd"] }
 embedded-hal = "0.2"
 cortex-m = "0.6"
 cortex-m-rt = "0.6"
 panic-halt = "0.2"
 nb = "1"
 panel-protocol = { path = "./panel-protocol" }
+usb-device = "0.2"
+usbd-serial = "0.1"

--- a/src/button.rs
+++ b/src/button.rs
@@ -1,7 +1,7 @@
 use core::convert::Infallible;
 use stm32f1xx_hal as hal;
 
-use cortex_m::peripheral::DWT;
+use cortex_m::peripheral::{DCB, DWT};
 use embedded_hal::digital::v2::InputPin;
 use hal::{
     rcc::Clocks,
@@ -36,8 +36,14 @@ enum ButtonState {
 }
 
 impl<T: InputPin<Error = Infallible>> Button<T> {
-    pub fn new(pin: Debouncer<T>, long_press_timeout_ms: u32, dwt: DWT, clocks: Clocks) -> Self {
-        let timer = MonoTimer::new(dwt, clocks);
+    pub fn new(
+        pin: Debouncer<T>,
+        long_press_timeout_ms: u32,
+        dwt: DWT,
+        dcb: DCB,
+        clocks: Clocks,
+    ) -> Self {
+        let timer = MonoTimer::new(dwt, dcb, clocks);
         let button_state = ButtonState::Released;
         let long_press_timeout_ticks =
             (timer.frequency().0 as f32 * (long_press_timeout_ms as f32 / 1000.0)) as u32;

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,8 +139,6 @@ fn main() -> ! {
     let debounced_encoder_pin = Debouncer::new(button_pin, Active::Low, 30, 3000);
     let mut encoder_button = Button::new(debounced_encoder_pin, 1000, cp.DWT, cp.DCB, clocks);
 
-    let mut brightness = 255;
-
     loop {
         match encoder_button.poll() {
             Some(ButtonEvent::Pressed) => {
@@ -167,12 +165,7 @@ fn main() -> ! {
         for command in protocol.poll().unwrap() {
             match command {
                 Command::Brightness { target, value } => match target {
-                    0 => {
-                        front_light.set_brightness(value);
-
-                        let factor = ((value as f32 / u16::MAX as f32) * 255.0) as u8;
-                        brightness = factor;
-                    },
+                    0 => front_light.set_brightness(value),
                     1 => back_light.set_brightness(value),
                     _ => {},
                 },
@@ -184,7 +177,5 @@ fn main() -> ! {
                 _ => {},
             }
         }
-
-        led_strip.set_all(Rgb::new(brightness, brightness, brightness));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn main() -> ! {
     let mut led = gpiob.pb12.into_push_pull_output(&mut gpiob.crh);
 
     // Set up USB communications
-    let usb_pin_d_plus = gpioa.pa12; //.into_push_pull_output(&mut gpioa.crh);
+    let usb_pin_d_plus = gpioa.pa12;
     let usb_pin_d_minus = gpioa.pa11;
 
     let usb = Peripheral { usb: dp.USB, pin_dm: usb_pin_d_minus, pin_dp: usb_pin_d_plus };

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -6,13 +6,16 @@ use hal::{
     rcc,
     serial::{self, Serial},
     stm32,
+    usb::{Peripheral, UsbBus},
 };
-use nb::{self, block};
 pub use panel_protocol::{Command, CommandReader, Report};
+use usb_device::{device::UsbDevice, UsbError};
+use usbd_serial::SerialPort;
 
 #[derive(Debug)]
 pub enum Error {
     Serial(hal::serial::Error),
+    UsbError(UsbError),
     BufferFull,
     MalformedMessage,
 }
@@ -20,6 +23,12 @@ pub enum Error {
 impl From<serial::Error> for Error {
     fn from(e: serial::Error) -> Error {
         Error::Serial(e)
+    }
+}
+
+impl From<UsbError> for Error {
+    fn from(e: UsbError) -> Error {
+        Error::UsbError(e)
     }
 }
 
@@ -32,49 +41,96 @@ impl From<panel_protocol::Error> for Error {
     }
 }
 
-pub struct SerialProtocol<PINS> {
+pub struct SerialProtocol<'a, PINS> {
     protocol: CommandReader,
-    serial: Serial<stm32::USART1, PINS>,
+    _serial: Serial<stm32::USART1, PINS>,
+
+    usb_device: UsbDevice<'a, UsbBus<Peripheral>>,
+    usb_serial_device: SerialPort<'a, UsbBus<Peripheral>>,
+    read_buf: [u8; 64],
 }
 
-impl<PINS: serial::Pins<stm32f1xx_hal::pac::USART1>> SerialProtocol<PINS> {
+impl<'a, PINS: serial::Pins<stm32f1xx_hal::pac::USART1>> SerialProtocol<'a, PINS> {
     pub fn new(
         usart1: stm32::USART1,
         usart_pins: PINS,
         afio: &mut afio::Parts,
         apb: &mut rcc::APB2,
         clocks: rcc::Clocks,
+        usb_device: usb_device::device::UsbDevice<
+            'a,
+            stm32f1xx_hal::usb::UsbBus<stm32f1xx_hal::usb::Peripheral>,
+        >,
+        usb_serial_device: usbd_serial::SerialPort<
+            'a,
+            stm32f1xx_hal::usb::UsbBus<stm32f1xx_hal::usb::Peripheral>,
+        >,
     ) -> Self {
         let serial_config = serial::Config::default().baudrate(115200.bps());
         let mapr = &mut afio.mapr;
         let serial = serial::Serial::usart1(usart1, usart_pins, mapr, serial_config, clocks, apb);
 
-        Self { protocol: CommandReader::new(), serial }
+        Self {
+            protocol: CommandReader::new(),
+            _serial: serial,
+            usb_device,
+            usb_serial_device,
+            read_buf: [0u8; 64],
+        }
     }
 
     /// Check to see if a new command from host is available
     pub fn poll(&mut self) -> Result<Option<Command>, Error> {
-        loop {
-            match self.serial.read() {
-                Ok(byte) => {
-                    if let Some(command) = self.protocol.process_byte(byte)? {
-                        break Ok(Some(command));
+        self.usb_device.poll(&mut [&mut self.usb_serial_device]);
+
+        match self.usb_serial_device.read(&mut self.read_buf) {
+            Ok(count) if count > 0 => {
+                for byte in &self.read_buf[..count] {
+                    if let Some(command) = self.protocol.process_byte(*byte)? {
+                        return Ok(Some(command));
                     }
-                },
-                Err(nb::Error::WouldBlock) => break Ok(None),
-                Err(nb::Error::Other(e)) => break Err(e.into()),
-            }
+                }
+
+                Ok(None)
+            },
+            Ok(_) => Ok(None),
+            Err(UsbError::WouldBlock) => Ok(None),
+            Err(e) => Err(e.into()),
         }
+
+        // loop {
+        //     match self.serial.read() {
+        //         Ok(byte) => {
+        //             if let Some(command) = self.protocol.process_byte(byte)? {
+        //                 break Ok(Some(command));
+        //             }
+        //         },
+        //         Err(nb::Error::WouldBlock) => break Ok(None),
+        //         Err(nb::Error::Other(e)) => break Err(e.into()),
+        //     }
+        // }
     }
 
     /// Sends a new report to the host, blocks until fully written or error occurs.
     pub fn report(&mut self, report: Report) -> Result<(), Error> {
         let report_bytes = report.as_arrayvec();
-        for byte in report_bytes.into_iter() {
-            // We can unwrap here because serial.write() returns an
-            // Infallible error.
-            block!(self.serial.write(byte)).unwrap();
+        let mut write_offset = 0;
+        let count = report_bytes.len();
+
+        while write_offset < count {
+            match self.usb_serial_device.write(&report_bytes[write_offset..count]) {
+                Ok(len) if len > 0 => {
+                    write_offset += len;
+                },
+                _ => {},
+            }
         }
+
+        // for byte in report_bytes.into_iter() {
+        //     // We can unwrap here because serial.write() returns an
+        //     // Infallible error.
+        //     block!(self.serial.write(byte)).unwrap();
+        // }
         Ok(())
     }
 }


### PR DESCRIPTION
This uses the on-board USB hardware peripheral of the STM32 instead of talking to a USB-serial converter. It should be faster and more robust against any timing issues in our firmware loop. It also allows for reading multiple bytes at a time instead of just one.

When connecting to the main computer, we'll use the micro USB port on the STM32 board instead of the blue CP2102 chip. We still need the CP2102 for flashing new firmware though, until we migrate to the STM32F4 series which has an onboard USB bootloader.