### PR TITLE
Use panic-reset instead of panic-halt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,10 +161,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "panic-halt"
-version = "0.2.0"
+name = "panic-reset"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de96540e0ebde571dc55c73d60ef407c653844e6f9a1e2fdbd40c07b9252d812"
+checksum = "acee8535a38487c5c70d61ee87284710452cb3b265304463f20a0c5327a4a8a5"
+dependencies = [
+ "cortex-m",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -236,7 +239,7 @@ dependencies = [
  "libm",
  "nb 1.0.0",
  "panel-protocol",
- "panic-halt",
+ "panic-reset",
  "stm32f4xx-hal",
  "usb-device",
  "usbd-serial",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ stm32f4xx-hal = { git = "https://github.com/bschwind/stm32f4xx-hal", version = "
 embedded-hal = "0.2"
 cortex-m = "0.6"
 cortex-m-rt = "0.6"
-panic-halt = "0.2"
+panic-reset = "0.1"
 nb = "1"
 panel-protocol = { git = "https://github.com/tonarino/panel-protocol.git", rev = "0.2" }
 usb-device = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-use panic_halt as _; // panic handler
+use panic_reset as _; // panic handler
 
 use stm32f4xx_hal as hal;
 


### PR DESCRIPTION
@skywhale please review

In general we should reduce the amount of panics as much as possible, though with our current protocol it may be better to simply panic and reset on an unrecognized message instead of attempting to recover.

Between halting or resetting though, I would definitely prefer resetting as that gives us a better chance of not needing physical access to the device if something goes wrong.