### PR TITLE
Make the firmware remotely updatable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,15 +17,21 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "as-slice"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4d1c23475b74e3672afa8c2be22040b8b7783ad9b461021144ed10a46bb0e6"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
 dependencies = [
- "generic-array 0.12.3",
- "generic-array 0.13.2",
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
  "generic-array 0.14.4",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bare-metal"
@@ -33,8 +39,14 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
+
+[[package]]
+name = "bare-metal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
 name = "bitfield"
@@ -44,30 +56,53 @@ checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
 name = "cast"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
+checksum = "57cdfa5d50aad6cb4d44dcab6101a7f79925bd59d82ca42f38a9856a28865374"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.3.3",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "cortex-m"
-version = "0.6.4"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88cdafeafba636c00c467ded7f1587210725a1adfab0c24028a7844b87738263"
+checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
 dependencies = [
  "aligned",
- "bare-metal",
+ "bare-metal 0.2.5",
  "bitfield",
+ "cortex-m 0.7.2",
+ "volatile-register",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643a210c1bdc23d0db511e2a576082f4ff4dcae9d0c37f50b431b8f8439d6d6b"
+dependencies = [
+ "bare-metal 0.2.5",
+ "bitfield",
+ "embedded-hal",
  "volatile-register",
 ]
 
 [[package]]
 name = "cortex-m-rt"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980c9d0233a909f355ed297ef122f257942de5e0a2cb1c39f60684b65bcb90fb"
+checksum = "b6d8353767db816419630a76d5f1ad5b09610d22b67ceb59647df6a8abc667f8"
 dependencies = [
  "cortex-m-rt-macros",
  "r0",
@@ -95,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "embedded-hal"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa998ce59ec9765d15216393af37a58961ddcefb14c753b4816ba2191d865fcb"
+checksum = "db184d3fa27bc7a2344250394c0264144dfe0bc81a4401801dcb964b8dd172ad"
 dependencies = [
  "nb 0.1.3",
  "void",
@@ -105,18 +140,18 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "generic-array"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
 dependencies = [
  "typenum",
 ]
@@ -153,10 +188,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "panel-firmware"
 version = "0.3.0"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "embedded-hal",
  "libm",
@@ -171,7 +225,6 @@ dependencies = [
 [[package]]
 name = "panel-protocol"
 version = "0.3.0"
-source = "git+https://github.com/tonarino/panel-protocol.git?rev=0.3#e8ecdc184680f05c29025c313f0a8894767ba5fc"
 dependencies = [
  "arrayvec",
 ]
@@ -182,23 +235,32 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acee8535a38487c5c70d61ee87284710452cb3b265304463f20a0c5327a4a8a5"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.6.7",
+]
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -211,9 +273,18 @@ checksum = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+
+[[package]]
+name = "rtcc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1048f7217bcd4bd977c01288e4973a69cf9195681f8b0b3a45d92ea21148f4a8"
+dependencies = [
+ "chrono",
+]
 
 [[package]]
 name = "rustc_version"
@@ -221,7 +292,16 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -230,7 +310,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -240,6 +329,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,29 +345,31 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stm32f4"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11460b4de3a84f072e2cf6e76306c64d27f405a0e83bace0a726f555ddf4bf33"
+checksum = "da3d56009c8f32e4f208dbea17df72484154d1040a8969b75d8c73eb7b18fe8f"
 dependencies = [
- "bare-metal",
- "cortex-m",
+ "bare-metal 0.2.5",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "vcell",
 ]
 
 [[package]]
 name = "stm32f4xx-hal"
-version = "0.8.3"
-source = "git+https://github.com/bschwind/stm32f4xx-hal?rev=880b3cda5aa666f8ab4aa1330ac50fdfd8700288#880b3cda5aa666f8ab4aa1330ac50fdfd8700288"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b4cb13b1bb36e7381eaf8941062b1eba172542b9d4f72dc50c35c4ac6260f2"
 dependencies = [
- "bare-metal",
+ "bare-metal 1.0.0",
  "cast",
- "cortex-m",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "embedded-dma",
  "embedded-hal",
- "nb 0.1.3",
+ "nb 1.0.0",
  "rand_core",
+ "rtcc",
  "stm32f4",
  "synopsys-usb-otg",
  "void",
@@ -277,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.58"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -288,32 +388,38 @@ dependencies = [
 
 [[package]]
 name = "synopsys-usb-otg"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461676dcf123675b3d3b02e2390e6a690cd186aacf2f439af7673c79e2561d53"
+checksum = "d1216cb0fe29f65bfffe03c364640202eed1291d85d2f62bbadbe670106786e5"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.6.7",
  "usb-device",
  "vcell",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "usb-device"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "849eed9b4dc61a1f17ba1d7a5078ceb095b9410caa38a506eb281ed5eff12fbd"
+checksum = "6be90410d4772074ea49525e2e753b65920b94b57eee21a6ef7b6a6fe6296245"
 
 [[package]]
 name = "usbd-serial"
@@ -334,9 +440,9 @@ checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "void"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,7 @@ dependencies = [
 [[package]]
 name = "panel-protocol"
 version = "0.3.0"
+source = "git+https://github.com/tonarino/panel-protocol.git?rev=0.4#b280cc1a28ee647bc52c5e08942aae4f81cdb0f3"
 dependencies = [
  "arrayvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,9 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-
-# Update after https://github.com/stm32-rs/stm32f4xx-hal/pull/238
-# stm32f4xx-hal = {version = "0.8", features = ["rt", "stm32f411", "usb_fs"] }
-stm32f4xx-hal = { git = "https://github.com/bschwind/stm32f4xx-hal", version = "0.8", features = ["rt", "stm32f411", "usb_fs"], rev = "880b3cda5aa666f8ab4aa1330ac50fdfd8700288" }
+stm32f4xx-hal = { version = "0.9", features = ["rt", "stm32f411", "usb_fs"] }
 embedded-hal = "0.2"
-cortex-m = "0.6"
+cortex-m = "0.7"
 cortex-m-rt = "0.6"
 panic-reset = "0.1"
 nb = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ cortex-m = "0.7"
 cortex-m-rt = "0.6"
 panic-reset = "0.1"
 nb = "1"
-panel-protocol = { git = "https://github.com/tonarino/panel-protocol.git", rev = "0.3" }
+panel-protocol = { git = "https://github.com/tonarino/panel-protocol.git", rev = "0.4" }
 usb-device = "0.2"
 usbd-serial = "0.1"
 libm = "0.2"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 serial-port := $(shell serial-monitor -f --index 0)
 
 flash:
-	(cargo build --release && cargo objcopy --release -- -O binary panel-brain-firmware.bin && dfu-util -D panel-brain-firmware.bin -d "0483:df11" -a 0 -s 0x08000000)
+	(cargo build --release && cargo objcopy --release -- -O binary panel-brain-firmware.bin && dfu-util -D panel-brain-firmware.bin -d "0483:df11" -a 0 -s 0x08000000:leave)
 
 flash-serial:
 	(cargo build --release && cargo objcopy --release -- -O binary panel-brain-firmware.bin && stm32flash -R -b 230400 -w panel-brain-firmware.bin -v $(serial-port))

--- a/README.md
+++ b/README.md
@@ -110,3 +110,19 @@ Set the baud rate with the `-b` flag:
 ```
 serial-monitor -b 9600 -p /dev/cu.SLAB_USBtoUART
 ```
+
+## Debugging with an STM32F103-based Board
+
+* Download the BlackMagic `v*.tar.gz` tarball release on [github](https://github.com/blacksphere/blackmagic/releases/)
+* Find `blackmagic_dfu_swlink.bin` in the tarball.
+* Using a USB-serial device, put an STM32F103 dev board (typically a blue-pill or black-pill) in bootloader mode (see the steps above).
+* Run `stm32flash -R -b 230400 -w blackmagic_dfu-swlink.bin -v <PATH_TO_YOUR_SERIAL_DEVICE_HERE>`
+* Get `blackmagic-native.bin` from the release tarball as well.
+* Run `dfu-util -d 1d50:6018,:6017 -s 0x08002000:leave -D blackmagic-native.bin`
+
+### Debugging
+* Attach the SWD wires from the blackmagic debug probe you just created to the target device. This is typically 4 wires: `3v3`, `GND`, `SWDIO`, and `SWCLK`.
+* Run `arm-none-eabi-gdb target/thumbv7em-none-eabihf/release/panel-firmware` (you will need a GNU ARM toolchain for this)
+* Inside gdb, run `target extended-remote /dev/cu.usbmodem95C55F961` (or wherever your blackmagic probe shows up as a device)
+* In gdb: `monitor swdp_scan`
+* In gdb: `attach 1`

--- a/src/bootload.rs
+++ b/src/bootload.rs
@@ -1,0 +1,71 @@
+use hal::stm32;
+use stm32f4xx_hal as hal;
+
+// This can be any number, it's only used to determine if we should
+// boot up in bootloader mode instead of running normally.
+const MAGIC_BOOTLOADER_NUMBER: u32 = 131981;
+
+// Which backup register we should read/write the magic number to.
+// The STM32F411 has 20 backup registers, each of which is 32-bits wide.
+const BACKUP_REGISTER_INDEX: usize = 0;
+
+// The location of the bootloader firmware in system memory.
+// Consult your STM32's datasheet or Application Note AN2602
+// for this value.
+const BOOTLOADER_FIRMWARE_MEMORY_LOCATION: u32 = 0x1FFF0000;
+
+pub fn request_bootloader() -> ! {
+    let dp = unsafe { stm32::Peripherals::steal() };
+
+    enable_backup_domain(&dp);
+    write_to_backup_register(MAGIC_BOOTLOADER_NUMBER, &dp);
+    disable_backup_domain(&dp);
+
+    cortex_m::peripheral::SCB::sys_reset();
+}
+
+pub fn jump_to_bootloader_if_requested(dp: &stm32::Peripherals) {
+    let magic_num: u32 = read_backup_register(dp);
+
+    if magic_num == MAGIC_BOOTLOADER_NUMBER {
+        enable_backup_domain(&dp);
+        write_to_backup_register(0, dp);
+        disable_backup_domain(&dp);
+
+        unsafe {
+            cortex_m::asm::bootload(BOOTLOADER_FIRMWARE_MEMORY_LOCATION as *const u32);
+        }
+    }
+}
+
+fn read_backup_register(dp: &stm32::Peripherals) -> u32 {
+    let rtc = &dp.RTC;
+    rtc.bkpr[BACKUP_REGISTER_INDEX].read().bkp().bits()
+}
+
+fn write_to_backup_register(val: u32, dp: &stm32::Peripherals) {
+    let rtc = &dp.RTC;
+    rtc.bkpr[BACKUP_REGISTER_INDEX].write(|w| w.bkp().bits(val));
+}
+
+fn enable_backup_domain(dp: &hal::stm32::Peripherals) {
+    let pwr = &dp.PWR;
+    let rcc = &dp.RCC;
+
+    // Enable the power interface clock by setting the PWREN bits in the RCC_APB1ENR register
+    rcc.apb1enr.write(|w| w.pwren().bit(true));
+
+    cortex_m::asm::dsb();
+
+    // Set the DBP bit in the Section 5.4.1 to enable access to the backup domain
+    pwr.cr.write(|w| w.dbp().bit(true));
+
+    // Enable the RTC clock by programming the RTCEN [15] bit in the Section 7.3.20: RCC Backup domain control register (RCC_BDCR)
+    rcc.bdcr.write(|w| w.rtcen().bit(true));
+}
+
+fn disable_backup_domain(dp: &stm32::Peripherals) {
+    let pwr = &dp.PWR;
+
+    pwr.cr.write(|w| w.dbp().bit(false));
+}

--- a/src/bootload.rs
+++ b/src/bootload.rs
@@ -55,6 +55,7 @@ fn enable_backup_domain(dp: &hal::stm32::Peripherals) {
     // Enable the power interface clock by setting the PWREN bits in the RCC_APB1ENR register
     rcc.apb1enr.write(|w| w.pwren().bit(true));
 
+    // Stall the pipeline to work around erratum 2.1.13 (DM00037591)
     cortex_m::asm::dsb();
 
     // Set the DBP bit in the Section 5.4.1 to enable access to the backup domain
@@ -65,7 +66,5 @@ fn enable_backup_domain(dp: &hal::stm32::Peripherals) {
 }
 
 fn disable_backup_domain(dp: &stm32::Peripherals) {
-    let pwr = &dp.PWR;
-
-    pwr.cr.write(|w| w.dbp().bit(false));
+    dp.PWR.cr.write(|w| w.dbp().bit(false));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use hal::{
 use usb_device::device::{UsbDeviceBuilder, UsbVidPid};
 use usbd_serial::{SerialPort, USB_CLASS_CDC};
 
+mod bootload;
 mod button;
 mod counter;
 mod overhead_light;
@@ -41,7 +42,7 @@ fn main() -> ! {
     let dp = stm32::Peripherals::take().expect("failed to get stm32 peripherals");
 
     // This call needs to happen as early as possible in the firmware.
-    jump_to_bootloader_if_requested(&dp);
+    bootload::jump_to_bootloader_if_requested(&dp);
 
     // Take ownership over the raw devices and convert them into the corresponding
     // HAL structs.
@@ -188,7 +189,7 @@ fn main() -> ! {
                 },
                 Command::Bootload => {
                     led.set_high().unwrap();
-                    request_bootloader();
+                    bootload::request_bootloader();
                 },
                 _ => {},
             }
@@ -202,156 +203,3 @@ fn main() -> ! {
         ));
     }
 }
-
-const MAGIC_BOOTLOADER_NUMBER: u32 = 131981;
-
-fn request_bootloader() -> ! {
-    let dp = unsafe { stm32::Peripherals::steal() };
-
-    enable_backup_domain(&dp);
-
-    let rtc = &dp.RTC;
-    let backup_register = &rtc.bkpr;
-
-    backup_register[0].write(|w| {
-        w.bkp().bits(MAGIC_BOOTLOADER_NUMBER)
-    });
-
-    cortex_m::asm::dsb();
-
-    disable_backup_domain(&dp);
-
-    cortex_m::peripheral::SCB::sys_reset();
-}
-
-fn enable_backup_domain(dp: &hal::stm32::Peripherals) {
-    let rtc = &dp.RTC;
-    let pwr = &dp.PWR;
-    let rcc = &dp.RCC;
-
-    // Enable the power interface clock by setting the PWREN bits in the RCC_APB1ENR register
-    rcc.apb1enr.write(|w| {
-        w.pwren().bit(true)
-    });
-
-    cortex_m::asm::dsb();
-
-    // Set the DBP bit in the Section 5.4.1 to enable access to the backup domain
-    pwr.cr.write(|w| {
-        w.dbp().bit(true)
-    });
-
-    // Select the RTC clock source
-    // if rcc.bdcr.read().lserdy().bit_is_clear() {
-    //     enable_lse(rcc, bypass);
-    // }
-
-    // Enable the RTC clock by programming the RTCEN [15] bit in the Section 7.3.20: RCC Backup domain control register (RCC_BDCR)
-    rcc.bdcr.write(|w| {
-        w.rtcen().bit(true)
-    });
-
-    // Disable write protect?
-    rtc.wpr.write(|w| {
-        unsafe { w.bits(0xCA) }
-    });
-
-    cortex_m::asm::dsb();
-
-    rtc.wpr.write(|w| {
-        unsafe { w.bits(0x53) }
-    });
-}
-
-fn disable_backup_domain(dp: &stm32::Peripherals) {
-    let pwr = &dp.PWR;
-
-    pwr.cr.write(|w| {
-        w.dbp().bit(false)
-    });
-}
-
-fn jump_to_bootloader_if_requested(dp: &stm32::Peripherals) {
-    let rtc = &dp.RTC;
-    let backup_register = &rtc.bkpr;
-
-    let magic_num: u32 = backup_register[0].read().bkp().bits();
-
-    if magic_num == MAGIC_BOOTLOADER_NUMBER {
-        enable_backup_domain(&dp);
-
-        backup_register[0].write(|w| {
-            w.bkp().bits(0u32)
-        });
-
-        disable_backup_domain(&dp);
-
-        unsafe {
-            cortex_m::asm::bootload(0x1FFF0000 as *const u32);
-        }
-    }
-}
-
-// fn bootloader() -> ! {
-//     // cortex_m::interrupt::disable();
-
-//     unsafe {
-//         let mut cp = cortex_m::Peripherals::steal();
-//         let dp = stm32::Peripherals::steal();
-
-//         // // Deinit the RCC
-//         let rcc = dp.RCC.constrain();
-//         let _clocks = rcc
-//             .cfgr
-//             .freeze();
-
-//         cortex_m::asm::dsb();
-
-//         // // Reset the SysTick timer
-//         cp.SYST.clear_current();
-
-//         cortex_m::asm::dsb();
-
-//         let rtc = dp.RTC;
-//         let backup_register = &rtc.bkpr;
-//         // 20 (32-bit) backup registers used to store 80 bytes
-//         // of user application data when VDD power is not present.
-//         backup_register[0].write(|w| {
-//             w.bkp().bits(MAGIC_BOOTLOADER_NUMBER)
-//         });
-//         // stm32f4xx_hal::stm32::rtc::BKPR.write();
-
-//         // // Disable interrupts
-//         // cortex_m::interrupt::disable();
-//         // cortex_m::asm::bootload(0x0010_0000 as *const u32);
-//         cortex_m::asm::bootload(0x1FFF0000 as *const u32);
-
-//         // cortex_m::asm::dsb();
-
-//         // 0x1FFF76DE - Bootloader memory location
-//         // 12 Kbyte starting from address 0x20000000
-//         // are used by the bootloader firmware for RAM
-//         // 29 Kbyte starting from address 0x1FFF0000,
-//         // contain the bootloader firmware
-//         // 0x20003000 - 0x2001FFFF: RAM
-//         // 0x1FFF0000 - 0x1FFF77FF: System Memory
-
-
-//         // cortex_m::asm::bootload(0x0 as *const u32);
-//         // cortex_m::asm::bootload(0x1FFF0000 as *const u32);
-//         // cortex_m::asm::bootload(0x08000000 as *const u32);
-//         // cortex_m::asm::bootstrap(0x20003000 as *const u32, 0x1FFF76DE as *const u32);
-//         // cortex_m::asm::bootstrap(0x1FFF0000 as *const u32, (0x1FFF0000 + 4) as *const u32);
-//     }
-
-//     // cortex_m::asm::bootload(0x00000004 as *const u32);
-//     // cortex_m::asm::bootload(0x08000000 as *const u32);
-//     // cortex_m::asm::bootload(0x0 as *const u32);
-//     // cortex_m::asm::bootload(0x1FFF76DE as *const u32);
-
-    
-//     // stm32f4xx_hal::pac::SCB::sys_reset();
-//     // unsafe {
-//     //     cortex_m::asm::bootload(0x1FFF0000 as *const u32);
-//     // }
-// }


### PR DESCRIPTION
@skywhale please review

Here's the basic summary of the changes:

* Add a `Bootload` command to tell the device to go into bootloader mode
* Write some "sentinel" value in an STM32 backup register (special registers that can survive system resets)
* Request a system reset
* On firmware startup, check the backup register for the sentinel value.
* If the sentinel value is present, reset it to `0` and jump to the bootloader
* If the sentinel value is not present, continue in the firmware as normal

The reason for this little dance instead of just jumping directly into the bootloader is that we would otherwise have to reset all device peripherals back to their default state, including USB devices, timers, etc.

It's much easier to simply reset and jump to the bootloader before we configure any hardware devices.

References:

* STM32F4 Backup Register Usage
https://www.st.com/resource/en/reference_manual/dm00119316-stm32f411xc-e-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf

<img width="1095" alt="Screen Shot 2021-05-21 at 3 11 46 PM" src="https://user-images.githubusercontent.com/458432/119090676-e1944600-ba46-11eb-96d7-3fedeafe5507.png">

* STM32 Bootloader Application Note AN2606
https://www.st.com/resource/en/application_note/cd00167594-stm32-microcontroller-system-memory-boot-mode-stmicroelectronics.pdf

<img width="700" alt="Screen Shot 2021-05-17 at 3 07 15 PM" src="https://user-images.githubusercontent.com/458432/119090731-f1ac2580-ba46-11eb-9224-7bbf6f58d2b3.png">
