### PR TITLE
Fix dial backlash (needs testing)

### DIFF
--- a/src/bootload.rs
+++ b/src/bootload.rs
@@ -28,9 +28,9 @@ pub fn jump_to_bootloader_if_requested(dp: &stm32::Peripherals) {
     let magic_num: u32 = read_backup_register(dp);
 
     if magic_num == MAGIC_BOOTLOADER_NUMBER {
-        enable_backup_domain(&dp);
+        enable_backup_domain(dp);
         write_to_backup_register(0, dp);
-        disable_backup_domain(&dp);
+        disable_backup_domain(dp);
 
         unsafe {
             cortex_m::asm::bootload(BOOTLOADER_FIRMWARE_MEMORY_LOCATION as *const u32);

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -1,26 +1,64 @@
-use hal::{prelude::*, qei::Qei, stm32::TIM1};
+use hal::{
+    prelude::*,
+    qei::Qei,
+    stm32::TIM1,
+    timer::{Instant, MonoTimer},
+};
 use stm32f4xx_hal as hal;
 
-pub struct Counter<PINS> {
+const DETENT_RESET_TIMOUT_MS: u32 = 200;
+
+pub struct Counter<'a, PINS> {
     qei: Qei<TIM1, PINS>,
+    // Cache for the count returned by qei for detecting changes
     last_count: u16,
+    timer: &'a MonoTimer,
+    last_update: Instant,
+    diff_accumulator: i16,
 }
 
-impl<PINS> Counter<PINS> {
-    pub fn new(qei: Qei<TIM1, PINS>) -> Self {
+impl<'a, PINS> Counter<'a, PINS> {
+    pub fn new(qei: Qei<TIM1, PINS>, timer: &'a MonoTimer) -> Self {
         let last_count = qei.count();
-        Counter { qei, last_count }
+        Counter { qei, last_count, last_update: timer.now(), timer, diff_accumulator: 0 }
     }
 
     pub fn poll(&mut self) -> Option<i8> {
         let count = self.qei.count();
-        let diff = count.wrapping_sub(self.last_count) as i16;
+
+        let diff = self.update_counts(count);
 
         if diff.abs() >= 4 {
-            self.last_count = count;
+            self.diff_accumulator = 0;
             Some((diff / 4) as i8)
         } else {
             None
         }
+    }
+
+    // Sometimes the accumulator gets out of sync with the physical detents. We require count to
+    // increment by 4 to fire a single tick but when the zero of accumulator lands in between
+    // detents (because of noise) we get backlash or missed ticks.
+    // Assume that when the dial rests for more than DETENT_RESET_TIMOUT_MS it is aligned to a detent
+    // and reset the accumulator.
+    fn update_counts(&mut self, count: u16) -> i16 {
+        if count != self.last_count {
+            self.last_update = self.timer.now();
+        }
+
+        if self.accumulator_timed_out() {
+            self.diff_accumulator = 0;
+        }
+
+        self.diff_accumulator += self.last_count.wrapping_sub(count) as i16;
+        self.last_count = count;
+
+        self.diff_accumulator
+    }
+
+    fn accumulator_timed_out(&self) -> bool {
+        let timeout_ticks =
+            self.timer.frequency().0 as f32 * (DETENT_RESET_TIMOUT_MS as f32 / 1000.0);
+        self.last_update.elapsed() > timeout_ticks as u32
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,7 @@ fn main() -> ! {
     let rotary_encoder_pins = (gpioa.pa8.into_alternate_af1(), gpioa.pa9.into_alternate_af1());
     let rotary_encoder = Qei::new(rotary_encoder_timer, rotary_encoder_pins);
 
-    let mut counter = Counter::new(rotary_encoder);
+    let mut counter = Counter::new(rotary_encoder, &timer);
 
     let button_pin = gpioa.pa10.into_pull_up_input();
     let debounced_encoder_pin = Debouncer::new(button_pin, Active::Low, 30, 3000);


### PR DESCRIPTION
We had a long debug session today with @bschwind and we found out the cause. This PR tries to solve it but it's a blind shot - I did not test this yet and the timeout duration is guesstimated.

# Cause

Our rotary encoder reports 4 increments per one physical detent and so in the firmware we [accumulate](https://github.com/tonarino/panel-firmware/blob/85540942acba71717b568b2d775ac1c21e0b199f/src/counter.rs#L19-L24) the increments and only report a tick when the accumulated value reaches 4.

Unfortunately the HW is little noisy and sometimes the detents' position drifts in relation to the increments. This causes our accumulator to be non-zero even though the dial is resting on  a detent. When this happens rotating the dial in one direction has no effect even if the rotation causes 4 increments.

Example (variable names match the code linked above):
- start with `last_count = 0`
- dial is rotated one tick to the right, `quei.count` reports 4, in turn we report a tick and set `last_count = 4`
- because \*noise\*, one more increment comes in and `quei.count` reports 5 as the dial settles on the detent position
- the button is rotated left, which makes `quei.count` to report 1 (the expected number since we expect 4 increments per detent) but we do not report anything because `last_count - count` is 3 (`4 - 1`)
- rotating right again, `quei.count` reports 5, which again doesn't trigger a tick because `last_count - count` is `-1`
- i.e. unless the count leaves the `(0, 8)` range we report no ticks but the two adjacent detents are located at `1` and `5`.

# Solution
There's no way for us to know where exactly the detents are located in relation to `count`. The only other dimension we can work with is time.

We can take advantage of the fact that users usually (and detented dials in general) stop for a brief while on the detents. In other words _whenever there's no rotation for a while, the dial is probably sitting on a detent_ and we should reset our accumulator.

This has two caveats:
1) When the dial stops in between dials we assume it's a detent. However, this should seldom happen and when it does it will be corrected the next time the dials slips to a detented position.
2) If the user rotates the button sufficiently slow between detents the rotation will not be registered as the accumulator will be reset before it has chance to accumulate 4 increments. This depends on how we tune the timeout duration. I believe it can be set to value such that reasonably slow ticks are safely registered.

This needs throughout testing. 


Fixes https://github.com/tonarino/portal/issues/2666