### PR TITLE
Change polarity

### DIFF
--- a/src/bootload.rs
+++ b/src/bootload.rs
@@ -28,9 +28,9 @@ pub fn jump_to_bootloader_if_requested(dp: &stm32::Peripherals) {
     let magic_num: u32 = read_backup_register(dp);
 
     if magic_num == MAGIC_BOOTLOADER_NUMBER {
-        enable_backup_domain(&dp);
+        enable_backup_domain(dp);
         write_to_backup_register(0, dp);
-        disable_backup_domain(&dp);
+        disable_backup_domain(dp);
 
         unsafe {
             cortex_m::asm::bootload(BOOTLOADER_FIRMWARE_MEMORY_LOCATION as *const u32);

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use cortex_m_rt::entry;
 use embedded_hal::digital::v2::OutputPin;
 use hal::{
     otg_fs::{UsbBus, USB},
+    pac::TIM1,
     prelude::*,
     pwm,
     qei::Qei,
@@ -117,6 +118,11 @@ fn main() -> ! {
     let rotary_encoder_timer = dp.TIM1;
     let rotary_encoder_pins = (gpioa.pa8.into_alternate_af1(), gpioa.pa9.into_alternate_af1());
     let rotary_encoder = Qei::new(rotary_encoder_timer, rotary_encoder_pins);
+    // Change the polarity of the encoder to Falling edge - it could better align with the detents of our volume dial.
+    // Taken form https://github.com/stm32-rs/stm32f4xx-hal/issues/410
+    unsafe {
+        (*TIM1::ptr()).ccer.write(|w| w.cc1p().set_bit().cc2p().set_bit());
+    }
 
     let mut counter = Counter::new(rotary_encoder);
 


### PR DESCRIPTION
Hardware-based alternative  to #31. Our hope is that this better aligns the encoder's ticks with the detents.

