### PR TITLE
Specify QEI Mode

### DIFF
--- a/src/bootload.rs
+++ b/src/bootload.rs
@@ -28,9 +28,9 @@ pub fn jump_to_bootloader_if_requested(dp: &stm32::Peripherals) {
     let magic_num: u32 = read_backup_register(dp);
 
     if magic_num == MAGIC_BOOTLOADER_NUMBER {
-        enable_backup_domain(&dp);
+        enable_backup_domain(dp);
         write_to_backup_register(0, dp);
-        disable_backup_domain(&dp);
+        disable_backup_domain(dp);
 
         unsafe {
             cortex_m::asm::bootload(BOOTLOADER_FIRMWARE_MEMORY_LOCATION as *const u32);

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -8,6 +8,16 @@ pub struct Counter<PINS> {
 
 impl<PINS> Counter<PINS> {
     pub fn new(qei: Qei<TIM1, PINS>) -> Self {
+        unsafe {
+            // TODO(bschwind) - Expose this functionality with a safe interface
+            //                  in stm32f4xx-hal.
+            // Change the mode of the QEI decoder to mode 1:
+            // Counter counts up/down on TI2FP1 edge depending on TI1FP2 level.
+            // Or in layman's terms, the encoder counts up and down on encoder
+            // pin A edges, while referencing the state of encoder pin B.
+            (*TIM1::ptr()).smcr.write(|w| w.sms().encoder_mode_1());
+        }
+
         let last_count = qei.count();
         Counter { qei, last_count }
     }

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -16,9 +16,9 @@ impl<PINS> Counter<PINS> {
         let count = self.qei.count();
         let diff = count.wrapping_sub(self.last_count) as i16;
 
-        if diff.abs() >= 4 {
+        if diff.abs() >= 2 {
             self.last_count = count;
-            Some((diff / 4) as i8)
+            Some((diff / 2) as i8)
         } else {
             None
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,6 @@ use cortex_m_rt::entry;
 use embedded_hal::digital::v2::OutputPin;
 use hal::{
     otg_fs::{UsbBus, USB},
-    pac::TIM1,
     prelude::*,
     pwm,
     qei::Qei,
@@ -118,16 +117,6 @@ fn main() -> ! {
     let rotary_encoder_timer = dp.TIM1;
     let rotary_encoder_pins = (gpioa.pa8.into_alternate_af1(), gpioa.pa9.into_alternate_af1());
     let rotary_encoder = Qei::new(rotary_encoder_timer, rotary_encoder_pins);
-
-    unsafe {
-        // Change the polarity of the encoder to Falling edge - it could better align with the detents of our volume dial.
-        // Taken form https://github.com/stm32-rs/stm32f4xx-hal/issues/410
-        // (*TIM1::ptr()).ccer.write(|w| w.cc1p().set_bit().cc2p().set_bit());
-
-        // Change the mode of the QEI decoder to mode 1:
-        // Counter counts up/down on TI2FP1 edge depending on TI1FP2 level.
-        (*TIM1::ptr()).smcr.write(|w| w.sms().encoder_mode_1());
-    }
 
     let mut counter = Counter::new(rotary_encoder);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,10 +118,15 @@ fn main() -> ! {
     let rotary_encoder_timer = dp.TIM1;
     let rotary_encoder_pins = (gpioa.pa8.into_alternate_af1(), gpioa.pa9.into_alternate_af1());
     let rotary_encoder = Qei::new(rotary_encoder_timer, rotary_encoder_pins);
-    // Change the polarity of the encoder to Falling edge - it could better align with the detents of our volume dial.
-    // Taken form https://github.com/stm32-rs/stm32f4xx-hal/issues/410
+
     unsafe {
-        (*TIM1::ptr()).ccer.write(|w| w.cc1p().set_bit().cc2p().set_bit());
+        // Change the polarity of the encoder to Falling edge - it could better align with the detents of our volume dial.
+        // Taken form https://github.com/stm32-rs/stm32f4xx-hal/issues/410
+        // (*TIM1::ptr()).ccer.write(|w| w.cc1p().set_bit().cc2p().set_bit());
+
+        // Change the mode of the QEI decoder to mode 1:
+        // Counter counts up/down on TI2FP1 edge depending on TI1FP2 level.
+        (*TIM1::ptr()).smcr.write(|w| w.sms().encoder_mode_1());
     }
 
     let mut counter = Counter::new(rotary_encoder);

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use cortex_m_rt::entry;
 use embedded_hal::digital::v2::OutputPin;
 use hal::{
     otg_fs::{UsbBus, USB},
+    pac::TIM1,
     prelude::*,
     pwm,
     qei::Qei,
@@ -117,6 +118,11 @@ fn main() -> ! {
     let rotary_encoder_timer = dp.TIM1;
     let rotary_encoder_pins = (gpioa.pa8.into_alternate_af1(), gpioa.pa9.into_alternate_af1());
     let rotary_encoder = Qei::new(rotary_encoder_timer, rotary_encoder_pins);
+    // Change the polarity of the encoder to Falling edge - it could better align with the detents of our volume dial.
+    // Taken form https://github.com/stm32-rs/stm32f4xx-hal/issues/410
+    unsafe {
+        (*TIM1::ptr()).ccer.write(|w| w.cc1p().set_bit().cc2p().set_bit());
+    }
 
     let mut counter = Counter::new(rotary_encoder);
 


### PR DESCRIPTION
This currently works, but drafting for now because we should create an appropriate higher-level interface to specify the mode without unsafe usage.

Some more research is still needed - I would have expected mode 2 to work, based on the [description](https://docs.rs/stm32f4xx-hal/latest/stm32f4xx_hal/pac/tim1/smcr/enum.SMS_A.html#variant.EncoderMode2), but maybe I have `TI1FP2` and `TI2FP1` mixed up.