### PR TITLE
Work around fuse getting tripped by fans spinning too fast

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -110,11 +110,15 @@ fn main() -> ! {
     // Start the "front light" PWM channels on full duty to work around
     // https://github.com/tonarino/portal/issues/6074. The effect on gen3 portals is that all fans
     // start at the lowest speed preventing the 12V fuse from tripping.
-    let mut front_light = OverheadLight::new(pwm1, pwm2, pwm3, pwm4, u16::MAX);
+    const INITIAL_DUTY: u16 = u16::MAX;
+    /// We observed that the fuse can sustain fans running at 80% speed.
+    /// Set the minimal duty to u16:MAX * 0.8 to cap the fan speed to 80%.
+    const MIN_DUTY: u16 = 52428;
+    let mut front_light = OverheadLight::new(pwm1, pwm2, pwm3, pwm4, INITIAL_DUTY, MIN_DUTY);
 
     // On gen3 portals these are the channels that control the light bar. Start them with zero duty
     // which is the same as the light-bar's own default to prevent flicker on power on.
-    let mut back_light = OverheadLight::new(pwm5, pwm6, pwm7, pwm8, 0);
+    let mut back_light = OverheadLight::new(pwm5, pwm6, pwm7, pwm8, 0, 0);
 
     // Connect a rotary encoder to pins A8 and A9.
     let rotary_encoder_timer = dp.TIM1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,18 +107,18 @@ fn main() -> ! {
     let (pwm1, pwm2, pwm3, pwm4) = pwm::tim5(dp.TIM5, back_light_pwm_pins, clocks, pwm_freq);
     let (pwm5, pwm6, pwm7, pwm8) = pwm::tim3(dp.TIM3, front_light_pwm_pins, clocks, pwm_freq);
 
-    // Start the "front light" PWM channels on full duty to work around
+    // Start the "front light" PWM channels on zero duty to work around
     // https://github.com/tonarino/portal/issues/6074. The effect on gen3 portals is that all fans
     // start at the lowest speed preventing the 12V fuse from tripping.
-    const INITIAL_DUTY: u16 = u16::MAX;
+    const INITIAL_DUTY: u16 = 0;
     /// We observed that the fuse can sustain fans running at 80% speed.
-    /// Set the minimal duty to u16:MAX * 0.8 to cap the fan speed to 80%.
-    const MIN_DUTY: u16 = 52428;
-    let mut front_light = OverheadLight::new(pwm1, pwm2, pwm3, pwm4, INITIAL_DUTY, MIN_DUTY);
+    /// Set the maximal duty to u16:MAX * 0.8 to cap the fan speed to 80%.
+    const MAX_DUTY: u16 = 52428;
+    let mut front_light = OverheadLight::new(pwm1, pwm2, pwm3, pwm4, INITIAL_DUTY, MAX_DUTY);
 
-    // On gen3 portals these are the channels that control the light bar. Start them with zero duty
+    // On gen3 portals these are the channels that control the light bar. Start them 100% duty
     // which is the same as the light-bar's own default to prevent flicker on power on.
-    let mut back_light = OverheadLight::new(pwm5, pwm6, pwm7, pwm8, 0, 0);
+    let mut back_light = OverheadLight::new(pwm5, pwm6, pwm7, pwm8, u16::MAX, u16::MAX);
 
     // Connect a rotary encoder to pins A8 and A9.
     let rotary_encoder_timer = dp.TIM1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,11 +107,14 @@ fn main() -> ! {
     let (pwm1, pwm2, pwm3, pwm4) = pwm::tim5(dp.TIM5, back_light_pwm_pins, clocks, pwm_freq);
     let (pwm5, pwm6, pwm7, pwm8) = pwm::tim3(dp.TIM3, front_light_pwm_pins, clocks, pwm_freq);
 
-    // The overhead light closer to the screen.
-    let mut front_light = OverheadLight::new(pwm1, pwm2, pwm3, pwm4);
+    // Start the "front light" PWM channels on full duty to work around
+    // https://github.com/tonarino/portal/issues/6074. The effect on gen3 portals is that all fans
+    // start at the lowest speed preventing the 12V fuse from tripping.
+    let mut front_light = OverheadLight::new(pwm1, pwm2, pwm3, pwm4, u16::MAX);
 
-    // The overhead light farther away from the screen.
-    let mut back_light = OverheadLight::new(pwm5, pwm6, pwm7, pwm8);
+    // On gen3 portals these are the channels that control the light bar. Start them with zero duty
+    // which is the same as the light-bar's own default to prevent flicker on power on.
+    let mut back_light = OverheadLight::new(pwm5, pwm6, pwm7, pwm8, 0);
 
     // Connect a rotary encoder to pins A8 and A9.
     let rotary_encoder_timer = dp.TIM1;

--- a/src/overhead_light.rs
+++ b/src/overhead_light.rs
@@ -11,6 +11,7 @@ where
     brightness_c2: P2,
     color_c1: P3,
     color_c2: P4,
+    min_duty: u16,
 }
 
 impl<P1, P2, P3, P4> OverheadLight<P1, P2, P3, P4>
@@ -26,6 +27,7 @@ where
         mut color_c1: P3,
         mut color_c2: P4,
         initial_duty: u16,
+        min_duty: u16,
     ) -> Self {
         brightness_c1.enable();
         brightness_c2.enable();
@@ -38,7 +40,7 @@ where
         color_c1.set_duty(initial_duty);
         color_c2.set_duty(initial_duty);
 
-        OverheadLight { brightness_c1, brightness_c2, color_c1, color_c2 }
+        OverheadLight { brightness_c1, brightness_c2, color_c1, color_c2, min_duty }
     }
 
     /// Sets the brightness of both channels.
@@ -50,6 +52,9 @@ where
 
         let adjusted = ((brightness as f32 / u16::MAX as f32)
             * self.brightness_c1.get_max_duty() as f32) as u16;
+
+        let adjusted = adjusted.max(self.min_duty);
+
         self.brightness_c1.set_duty(adjusted);
         self.brightness_c2.set_duty(adjusted);
     }
@@ -63,6 +68,9 @@ where
 
         let adjusted =
             ((color as f32 / u16::MAX as f32) * self.color_c1.get_max_duty() as f32) as u16;
+
+        let adjusted = adjusted.max(self.min_duty);
+
         self.color_c1.set_duty(adjusted);
         self.color_c2.set_duty(adjusted);
     }

--- a/src/overhead_light.rs
+++ b/src/overhead_light.rs
@@ -25,19 +25,18 @@ where
         mut brightness_c2: P2,
         mut color_c1: P3,
         mut color_c2: P4,
+        initial_duty: u16,
     ) -> Self {
         brightness_c1.enable();
         brightness_c2.enable();
         color_c1.enable();
         color_c2.enable();
 
-        // Set maximum brightness
-        brightness_c1.set_duty(0);
-        brightness_c2.set_duty(0);
+        brightness_c1.set_duty(initial_duty);
+        brightness_c2.set_duty(initial_duty);
 
-        // Set white color temperature
-        color_c1.set_duty(0);
-        color_c2.set_duty(0);
+        color_c1.set_duty(initial_duty);
+        color_c2.set_duty(initial_duty);
 
         OverheadLight { brightness_c1, brightness_c2, color_c1, color_c2 }
     }

--- a/src/overhead_light.rs
+++ b/src/overhead_light.rs
@@ -11,7 +11,7 @@ where
     brightness_c2: P2,
     color_c1: P3,
     color_c2: P4,
-    min_duty: u16,
+    max_duty: u16,
 }
 
 impl<P1, P2, P3, P4> OverheadLight<P1, P2, P3, P4>
@@ -27,33 +27,33 @@ where
         mut color_c1: P3,
         mut color_c2: P4,
         initial_duty: u16,
-        min_duty: u16,
+        max_duty: u16,
     ) -> Self {
         brightness_c1.enable();
         brightness_c2.enable();
         color_c1.enable();
         color_c2.enable();
 
+        // Invert the value because our transistor circuit inverts the PWM signal.
+        let initial_duty = u16::MAX - initial_duty;
         brightness_c1.set_duty(initial_duty);
         brightness_c2.set_duty(initial_duty);
-
         color_c1.set_duty(initial_duty);
         color_c2.set_duty(initial_duty);
 
-        OverheadLight { brightness_c1, brightness_c2, color_c1, color_c2, min_duty }
+        OverheadLight { brightness_c1, brightness_c2, color_c1, color_c2, max_duty }
     }
 
     /// Sets the brightness of both channels.
     /// 0 = Off
     /// u16::MAX = Full brightness
     pub fn set_brightness(&mut self, brightness: u16) {
+        let brightness = brightness.min(self.max_duty);
         // Invert the value because our transistor circuit inverts the PWM signal.
         let brightness = u16::MAX - brightness;
 
         let adjusted = ((brightness as f32 / u16::MAX as f32)
             * self.brightness_c1.get_max_duty() as f32) as u16;
-
-        let adjusted = adjusted.max(self.min_duty);
 
         self.brightness_c1.set_duty(adjusted);
         self.brightness_c2.set_duty(adjusted);
@@ -63,13 +63,12 @@ where
     /// 0 = Full yellow
     /// u16::MAX = Full white
     pub fn set_color_temperature(&mut self, color: u16) {
+        let color = color.min(self.max_duty);
         // Invert the value because our transistor circuit inverts the PWM signal.
         let color = u16::MAX - color;
 
         let adjusted =
             ((color as f32 / u16::MAX as f32) * self.color_c1.get_max_duty() as f32) as u16;
-
-        let adjusted = adjusted.max(self.min_duty);
 
         self.color_c1.set_duty(adjusted);
         self.color_c2.set_duty(adjusted);


### PR DESCRIPTION
Prevent https://github.com/tonarino/portal/issues/6074 from getting triggered (as much) in gen3 batch1 portals that have the v0.4 (or possible v0.5) panel-controller PCBs.

Pasting the commit messages here:


### [Set initial PWM duty for fans to 100%](https://github.com/tonarino/panel-firmware/commit/7fad46f4593924202ce7d5989f9d0a5e80cc9644)

There's a fuse on the v0.4 panel controller PCB that gets tripped when the fans spin too fast (>~80% speed). 

When the fuse trips, we loose control of the light bar which is controlled by another pwm signal sourced through the same fuse. The fans also slow down to a very slow speed.

The fuse can be reset by lowering the requested speed of the fans down to around zero. Then they stop trying to draw as much power letting the fuse to reset.

The control signal of the fans is such that zero PWM duty corresponds to maximum fan speed, and 100% duty to lowest fan speed.

During tonari power-up we have this sequence of events:
1. power is applied and the 12V brick starts providing DC power to the panel controller. At this point the firmware is not running because the PC is not supplying USB power yet. The fans thus spin at full speed. This lasts about 3 seconds.
2. the PC starts booting up and panel controller firmware starts running having usb power. The initial PWM duty is zero though so the fans continue spinning at full speed. This can last about half a minute.
3. the tonari binary starts up and sends commands to the panel controller to set the configured fan speed, which is usually around 80%. By this time the fuse is tripped.

This commit changes the sequence such that during the second phase we set PWM duty to 100% effectively slowing the fans all the way down. If the fuse still tripped during the first phase it should reset at this point.

### [Limit fan speed to 80% on gen3 portals](https://github.com/tonarino/panel-firmware/commit/fa5846910c722c92043606c619b8e3535ff99302)

In addition to starting with the slowest fan speed also limit the fan speed to 80% of their maximum to prevent tripping the fuse by misconfiguration in the tonari config or by eg. the hardware check feature which can spin the fans at full speed temporarily.

### Testing
On a portal with v0.4 or v0.5 panel controller before deploying this firmware.
- [x] Make sure full-power fan speed of both channels is configured to `0.8` and the temperature to 1. Power cycle the portal. Observe that after the power cycle the fuse gets tripped indicated by 1) fans spinning very slow 2) the light shining the default color and temperature even after the tonari binary starts. Then configuring the fan speed to 0 for both channels, the fuse resets indicated by the light changing to the configured color.
- [x] with the fuse reset, configure the fan speed to max on both channels. The fuse trips indicated by the light changing temperature.

Deploy this firmware. 

- [x] Power cycle the portal. Immediately after the power-on, observe that the fans start spinning fast for about 3-5 seconds. The fuse may or may not trip at this point. The may flicker.
- [x] after that the fans slow down to the lowest speed and stay there until the tonari binary starts
- [x] once the binary starts the fan speed up to the configured speed. Light still has configured temperature.
- [x] with the fuse reset, set the fan speed to 0.8 on both channels. Then increase it to 1.0 there should be no observable change in speed (noise). The fuse should not trip anymore.
- [x] do the hardware check and check it checks
