### PR TITLE
GPIO-based quadrature decoder

### DIFF
--- a/src/counter.rs
+++ b/src/counter.rs
@@ -1,59 +1,31 @@
 use core::convert::Infallible;
 use embedded_hal::digital::v2::InputPin;
 
-// How many up/down edges occur on either the A or B pins from one
-// physical detent to the next. Most encoders have 4 edges, but
-// ours has 2, and others could have a different number.
-const EDGES_PER_DETENT: i8 = 4;
-
 pub struct Counter<A: InputPin, B: InputPin> {
-    // qei: Qei<TIM1, PINS>,
     pin_a: A,
     pin_b: B,
     prev_state: (bool, bool),
-    pulse_count: i8,
 }
 
-impl<A: InputPin<Error=Infallible>, B: InputPin<Error=Infallible>> Counter<A, B> {
+impl<A: InputPin<Error = Infallible>, B: InputPin<Error = Infallible>> Counter<A, B> {
     pub fn new(pin_a: A, pin_b: B) -> Self {
         let prev_state = read_state(&pin_a, &pin_b);
 
-        Self {
-            pin_a,
-            pin_b,
-            prev_state,
-            pulse_count: 0,
-        }
+        Self { pin_a, pin_b, prev_state }
     }
 
     pub fn poll(&mut self) -> Option<i8> {
-        let mut dial_diff = None;
-
         let curr_state = read_state(&self.pin_a, &self.pin_b);
 
-        // Valid transitions
-        // Clockwise:
-        //     00 -> 10 -> 11 -> 01 -> 00
-        // Counter-clockwise:
-        //     00 -> 01 -> 11 -> 10 -> 00
-        match (self.prev_state, curr_state) {
-            ((false, false), (false, true))
-            | ((false, true), (true, true))
-            | ((true, true), (true, false))
-            | ((true, false), (false, false)) => self.pulse_count -= 1,
-            ((false, false), (true, false))
-            | ((true, false), (true, true))
-            | ((true, true), (false, true))
-            | ((false, true), (false, false)) => self.pulse_count += 1,
-            _ => {},
-        }
-
-        if self.pulse_count.abs() >= EDGES_PER_DETENT {
-            // Will be -1 or +1
-            let diff = self.pulse_count.signum();
-            self.pulse_count = 0;
-            dial_diff = Some(diff);
-        }
+        // We only count a pulse on the rising or falling edge of B, and
+        // the direction depends on the level of A, which should be unchanged
+        // as B rises or falls. The falling edge of B should be roughly in the
+        // middle of the two detents, according to the Alps EC20A datasheet.
+        let dial_diff = match (self.prev_state, curr_state) {
+            ((false, true), (false, false)) => Some(1),
+            ((false, false), (false, true)) => Some(-1),
+            _ => None,
+        };
 
         self.prev_state = curr_state;
 
@@ -61,6 +33,9 @@ impl<A: InputPin<Error=Infallible>, B: InputPin<Error=Infallible>> Counter<A, B>
     }
 }
 
-fn read_state<A: InputPin<Error=Infallible>, B: InputPin<Error=Infallible>>(a: &A, b: &B) -> (bool, bool) {
+fn read_state(
+    a: &dyn InputPin<Error = Infallible>,
+    b: &dyn InputPin<Error = Infallible>,
+) -> (bool, bool) {
     (a.is_high().unwrap(), b.is_high().unwrap())
 }

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -4,6 +4,7 @@ use embedded_hal::digital::v2::InputPin;
 pub struct Counter<A: InputPin, B: InputPin> {
     pin_a: A,
     pin_b: B,
+    /// The last sampled levels of (A, B) pins.
     prev_state: (bool, bool),
 }
 

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -1,36 +1,66 @@
-use hal::{prelude::*, qei::Qei, stm32::TIM1};
-use stm32f4xx_hal as hal;
+use core::convert::Infallible;
+use embedded_hal::digital::v2::InputPin;
 
-pub struct Counter<PINS> {
-    qei: Qei<TIM1, PINS>,
-    last_count: u16,
+// How many up/down edges occur on either the A or B pins from one
+// physical detent to the next. Most encoders have 4 edges, but
+// ours has 2, and others could have a different number.
+const EDGES_PER_DETENT: i8 = 4;
+
+pub struct Counter<A: InputPin, B: InputPin> {
+    // qei: Qei<TIM1, PINS>,
+    pin_a: A,
+    pin_b: B,
+    prev_state: (bool, bool),
+    pulse_count: i8,
 }
 
-impl<PINS> Counter<PINS> {
-    pub fn new(qei: Qei<TIM1, PINS>) -> Self {
-        unsafe {
-            // TODO(bschwind) - Expose this functionality with a safe interface
-            //                  in stm32f4xx-hal.
-            // Change the mode of the QEI decoder to mode 1:
-            // Counter counts up/down on TI2FP1 edge depending on TI1FP2 level.
-            // Or in layman's terms, the encoder counts up and down on encoder
-            // pin A edges, while referencing the state of encoder pin B.
-            (*TIM1::ptr()).smcr.write(|w| w.sms().encoder_mode_1());
-        }
+impl<A: InputPin<Error=Infallible>, B: InputPin<Error=Infallible>> Counter<A, B> {
+    pub fn new(pin_a: A, pin_b: B) -> Self {
+        let prev_state = read_state(&pin_a, &pin_b);
 
-        let last_count = qei.count();
-        Counter { qei, last_count }
+        Self {
+            pin_a,
+            pin_b,
+            prev_state,
+            pulse_count: 0,
+        }
     }
 
     pub fn poll(&mut self) -> Option<i8> {
-        let count = self.qei.count();
-        let diff = count.wrapping_sub(self.last_count) as i16;
+        let mut dial_diff = None;
 
-        if diff.abs() >= 2 {
-            self.last_count = count;
-            Some((diff / 2) as i8)
-        } else {
-            None
+        let curr_state = read_state(&self.pin_a, &self.pin_b);
+
+        // Valid transitions
+        // Clockwise:
+        //     00 -> 10 -> 11 -> 01 -> 00
+        // Counter-clockwise:
+        //     00 -> 01 -> 11 -> 10 -> 00
+        match (self.prev_state, curr_state) {
+            ((false, false), (false, true))
+            | ((false, true), (true, true))
+            | ((true, true), (true, false))
+            | ((true, false), (false, false)) => self.pulse_count -= 1,
+            ((false, false), (true, false))
+            | ((true, false), (true, true))
+            | ((true, true), (false, true))
+            | ((false, true), (false, false)) => self.pulse_count += 1,
+            _ => {},
         }
+
+        if self.pulse_count.abs() >= EDGES_PER_DETENT {
+            // Will be -1 or +1
+            let diff = self.pulse_count.signum();
+            self.pulse_count = 0;
+            dial_diff = Some(diff);
+        }
+
+        self.prev_state = curr_state;
+
+        dial_diff
     }
+}
+
+fn read_state<A: InputPin<Error=Infallible>, B: InputPin<Error=Infallible>>(a: &A, b: &B) -> (bool, bool) {
+    (a.is_high().unwrap(), b.is_high().unwrap())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,6 @@ use hal::{
     otg_fs::{UsbBus, USB},
     prelude::*,
     pwm,
-    qei::Qei,
     spi::{Mode as SpiMode, NoMiso, NoSck, Phase, Polarity, Spi},
     stm32,
     timer::MonoTimer,
@@ -114,11 +113,7 @@ fn main() -> ! {
     let mut back_light = OverheadLight::new(pwm5, pwm6, pwm7, pwm8);
 
     // Connect a rotary encoder to pins A8 and A9.
-    let rotary_encoder_timer = dp.TIM1;
-    let rotary_encoder_pins = (gpioa.pa8.into_alternate_af1(), gpioa.pa9.into_alternate_af1());
-    let rotary_encoder = Qei::new(rotary_encoder_timer, rotary_encoder_pins);
-
-    let mut counter = Counter::new(rotary_encoder);
+    let mut counter = Counter::new(gpioa.pa8, gpioa.pa9);
 
     let button_pin = gpioa.pa10.into_pull_up_input();
     let debounced_encoder_pin = Debouncer::new(button_pin, Active::Low, 30, 3000);


### PR DESCRIPTION
For the most part, using the built-in STM32 quadrature decoder in x2 mode has worked well, but it still seems to be susceptible to noise. We had more success using a custom GPIO-based solution on the dial display, so I'm attempting the same here.

There's a difference between the dial display's encoder and the old volume dial we used, thus the different code. Looking at the encoder's datasheet, we decided to only count pulses on the rising and falling edge of B, while taking the level of A into account:

<img width="1235" height="439" alt="290739701-0c05dd28-2421-43d5-ab38-a6a387145e20" src="https://github.com/user-attachments/assets/43f5f079-9542-4fa2-93d2-31922d546ed2" />

So with this code, the dial will "turn" when you're roughly halfway in between detents. I've tested this one pretty extensively on my dial, but I'm not sure how well it will perform on some of the noisy dials we have in production.